### PR TITLE
Media handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,4 +10,5 @@ type App struct {
 	API         *API
 	Config      *Config
 	HaveAccount bool
+	FileList    []string
 }

--- a/authoverlay.go
+++ b/authoverlay.go
@@ -66,7 +66,7 @@ func (a *AuthOverlay) GotInput() {
 			return
 		}
 		a.account = acc
-		openURL(acc.AuthURI)
+		openURL(a.app.Config.Media, acc.AuthURI)
 		a.Input.SetText("")
 		a.authStep = authCodeStep
 		a.Draw()

--- a/config.go
+++ b/config.go
@@ -53,6 +53,8 @@ type MediaConfig struct {
 	AudioViewer string
 	AudioArgs   []string
 	AudioSingle bool
+	LinkViewer  string
+	LinkArgs    []string
 }
 
 func parseColor(input string, def string) tcell.Color {
@@ -173,6 +175,15 @@ func parseMedia(cfg *ini.File) MediaConfig {
 	}
 	media.AudioSingle = cfg.Section("media").Key("audio-single").MustBool(true)
 
+	linkViewerComponents := strings.Fields(cfg.Section("media").Key("link-viewer").String())
+	if len(linkViewerComponents) == 0 {
+		media.LinkViewer = "xdg-open"
+		media.LinkArgs = []string{}
+	} else {
+		media.LinkViewer = linkViewerComponents[0]
+		media.LinkArgs = linkViewerComponents[1:]
+	}
+
 	return media
 }
 
@@ -266,6 +277,10 @@ audio-viewer=xdg-open
 # If audio files should open one by one. See above comment about image-single
 # default=true
 audio-single=true
+
+# Your web browser
+# default=xdg-open
+link-viewer=xdg-open
 
 [style]
 # All styles can be represented in their HEX value like #ffffff or

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/gdamore/tcell"
 	"github.com/kyoh86/xdg"
@@ -44,10 +45,13 @@ type StyleConfig struct {
 
 type MediaConfig struct {
 	ImageViewer string
+	ImageArgs   []string
 	ImageSingle bool
 	VideoViewer string
+	VideoArgs   []string
 	VideoSingle bool
 	AudioViewer string
+	AudioArgs   []string
 	AudioSingle bool
 }
 
@@ -139,25 +143,34 @@ func parseGeneral(cfg *ini.File) GeneralConfig {
 
 func parseMedia(cfg *ini.File) MediaConfig {
 	media := MediaConfig{}
-	imageViewer := cfg.Section("media").Key("image-viewer").String()
-	if imageViewer == "" {
-		imageViewer = "xdg-open"
+	imageViewerComponents := strings.Fields(cfg.Section("media").Key("image-viewer").String())
+	if len(imageViewerComponents) == 0 {
+		media.ImageViewer = "xdg-open"
+		media.ImageArgs = []string{}
+	} else {
+		media.ImageViewer = imageViewerComponents[0]
+		media.ImageArgs = imageViewerComponents[1:]
 	}
-	media.ImageViewer = imageViewer
 	media.ImageSingle = cfg.Section("media").Key("image-single").MustBool(true)
 
-	videoViewer := cfg.Section("media").Key("video-viewer").String()
-	if videoViewer == "" {
-		videoViewer = "xdg-open"
+	videoViewerComponents := strings.Fields(cfg.Section("media").Key("video-viewer").String())
+	if len(videoViewerComponents) == 0 {
+		media.VideoViewer = "xdg-open"
+		media.VideoArgs = []string{}
+	} else {
+		media.VideoViewer = videoViewerComponents[0]
+		media.VideoArgs = videoViewerComponents[1:]
 	}
-	media.VideoViewer = videoViewer
 	media.VideoSingle = cfg.Section("media").Key("video-single").MustBool(true)
 
-	audioViewer := cfg.Section("media").Key("audio-viewer").String()
-	if audioViewer == "" {
-		videoViewer = "xdg-open"
+	audioViewerComponents := strings.Fields(cfg.Section("media").Key("audio-viewer").String())
+	if len(audioViewerComponents) == 0 {
+		media.AudioViewer = "xdg-open"
+		media.AudioArgs = []string{}
+	} else {
+		media.AudioViewer = audioViewerComponents[0]
+		media.AudioArgs = audioViewerComponents[1:]
 	}
-	media.AudioViewer = audioViewer
 	media.AudioSingle = cfg.Section("media").Key("audio-single").MustBool(true)
 
 	return media

--- a/linkoverlay.go
+++ b/linkoverlay.go
@@ -85,7 +85,7 @@ func (l *LinkOverlay) Open() {
 		return
 	}
 	if index < len(l.urls) {
-		openURL(l.urls[index].URL)
+		openURL(l.app.Config.Media, l.urls[index].URL)
 		return
 	}
 	mIndex := index - len(l.urls)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"os"
 
 	"github.com/gdamore/tcell"
 )
@@ -77,6 +78,8 @@ func main() {
 	} else {
 		app.UI.LoggedIn()
 	}
+
+	app.FileList = []string{}
 
 	app.UI.Root.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if !app.HaveAccount {
@@ -241,5 +244,9 @@ func main() {
 
 	if err := app.UI.Root.SetRoot(app.UI.Pages, true).Run(); err != nil {
 		panic(err)
+	}
+
+	for _, f := range app.FileList {
+		os.Remove(f)
 	}
 }

--- a/ui.go
+++ b/ui.go
@@ -220,6 +220,7 @@ func (ui *UI) OpenMedia(status *mastodon.Status) {
 			files = append(files, f)
 		}
 		go openMediaType(ui.app.Config.Media, files, key)
+		ui.app.FileList = append(ui.app.FileList, files...)
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -137,10 +137,6 @@ func openMediaType(conf MediaConfig, filenames []string, mediaType string) {
 			exec.Command(conf.AudioViewer, args...).Run()
 		}
 	}
-
-	for _, f := range filenames {
-		os.Remove(f)
-	}
 }
 
 func downloadFile(url string) (string, error) {

--- a/util.go
+++ b/util.go
@@ -109,26 +109,32 @@ func openMediaType(conf MediaConfig, filenames []string, mediaType string) {
 	case "image":
 		if conf.ImageSingle {
 			for _, f := range filenames {
-				exec.Command(conf.ImageViewer, f).Run()
+				args := append(conf.ImageArgs, f)
+				exec.Command(conf.ImageViewer, args...).Run()
 			}
 		} else {
-			exec.Command(conf.ImageViewer, filenames...).Run()
+			args := append(conf.ImageArgs, filenames...)
+			exec.Command(conf.ImageViewer, args...).Run()
 		}
 	case "video", "gifv":
 		if conf.VideoSingle {
 			for _, f := range filenames {
-				exec.Command(conf.VideoViewer, f).Run()
+				args := append(conf.VideoArgs, f)
+				exec.Command(conf.VideoViewer, args...).Run()
 			}
 		} else {
-			exec.Command(conf.VideoViewer, filenames...).Run()
+			args := append(conf.VideoArgs, filenames...)
+			exec.Command(conf.VideoViewer, args...).Run()
 		}
 	case "audio":
 		if conf.AudioSingle {
 			for _, f := range filenames {
-				exec.Command(conf.AudioViewer, f).Run()
+				args := append(conf.AudioArgs, f)
+				exec.Command(conf.AudioViewer, args...).Run()
 			}
 		} else {
-			exec.Command(conf.AudioViewer, filenames...).Run()
+			args := append(conf.AudioArgs, filenames...)
+			exec.Command(conf.AudioViewer, args...).Run()
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -100,8 +100,9 @@ func openEditor(app *tview.Application, content string) (string, error) {
 	return strings.TrimSpace(string(text)), nil
 }
 
-func openURL(url string) {
-	exec.Command("xdg-open", url).Start()
+func openURL(conf MediaConfig, url string) {
+	args := append(conf.LinkArgs, url)
+	exec.Command(conf.LinkViewer, args...).Start()
 }
 
 func openMediaType(conf MediaConfig, filenames []string, mediaType string) {


### PR DESCRIPTION
Allows options to be passed to external media viewers specified in the config file.
Persists files until tut itself exits because exec.Command().Run() may return before deletion is appropriate.