### PR TITLE
Use visibility for previous message when replying

### DIFF
--- a/messagebox.go
+++ b/messagebox.go
@@ -90,8 +90,8 @@ func (m *MessageBox) composeToot(status *mastodon.Status) {
 		mt.Status = status
 	}
 	visibility := mastodon.VisibilityPublic
-	if status != nil && status.Visibility == mastodon.VisibilityDirectMessage {
-		visibility = mastodon.VisibilityDirectMessage
+	if status != nil {
+		visibility = status.Visibility
 	}
 	m.app.UI.VisibilityOverlay.SetVisibilty(visibility)
 


### PR DESCRIPTION
Instead of only using the "public" or "direct" visibility, it uses whatever is in `status.Visibility`. This is consistent with other clients behavior, as people who use it often prefer to reply with the same visibility when replying.

I see that this already occurred with DMs, but I don't know why this wasn't extended to the rest of the visibility options since the code was so simple. Maybe this didn't work or was buggy when you tried it before? 