### PR TITLE
Implement cycling between different feeds and timelines

### DIFF
--- a/statusview.go
+++ b/statusview.go
@@ -127,7 +127,7 @@ func (t *StatusView) CyclePreviousFeed() {
 
 }
 
-func (t *StatusView) RemoveLatestFeed() {
+func (t *StatusView) RemoveCurrentFeed() {
 	t.feeds = t.feeds[:t.feedIndex+copy(t.feeds[t.feedIndex:], t.feeds[t.feedIndex+1:])]
 
 	if t.feedIndex == len(t.feeds) {
@@ -229,7 +229,7 @@ func (t *StatusView) inputBoth(event *tcell.EventKey) {
 
 func (t *StatusView) inputBack(q bool) {
 	if t.app.UI.Focus == LeftPaneFocus && len(t.feeds) > 1 {
-		t.RemoveLatestFeed()
+		t.RemoveCurrentFeed()
 	} else if t.app.UI.Focus == LeftPaneFocus && q {
 		t.app.UI.Root.Stop()
 	} else if t.app.UI.Focus == NotificationPaneFocus {

--- a/statusview.go
+++ b/statusview.go
@@ -131,6 +131,7 @@ func (t *StatusView) CyclePreviousFeed() {
 }
 
 func (t *StatusView) RemoveCurrentFeed() {
+	t.feeds[t.feedIndex] = nil
 	t.feeds = t.feeds[:t.feedIndex+copy(t.feeds[t.feedIndex:], t.feeds[t.feedIndex+1:])]
 
 	if t.feedIndex == len(t.feeds) {

--- a/statusview.go
+++ b/statusview.go
@@ -124,6 +124,9 @@ func (t *StatusView) CyclePreviousFeed() {
 		feed.DrawToot()
 	}
 	t.drawDesc()
+	if feed.GetSavedIndex() < 4 {
+		t.loadNewer()
+	}
 
 }
 
@@ -552,6 +555,7 @@ func (t *StatusView) loadNewer() {
 			}
 			t.list.SetCurrentItem(newIndex)
 			t.loadingNewer = false
+			t.feeds[feedIndex].DrawToot()
 		})
 	}()
 }


### PR DESCRIPTION
Hey there, great project!
I saw that a queue of feeds was present but impossible to cycle through them, I like to be able to switch between the feeds I opened, so that the timelines stay at the same position and don't get reset every time I open them.
It is now possible to cycle through all the opened timelines, threads and so on pressing the letter 'h'.
I used the changes for a while and everything seems to work correctly, however it might be better if you check as well.

I'm sorry that I didn't discuss about this before, but I implemented it for myself anyways... If you don't believe this will be useful feel free to delete the PR.

Greetings