### PR TITLE
Correct inconsistent feed selection behavior

### DIFF
--- a/statusview.go
+++ b/statusview.go
@@ -89,7 +89,7 @@ func (t *StatusView) AddFeed(f Feed) {
 	f.DrawToot()
 	t.drawDesc()
 
-	if t.lastList == NotificationPaneFocus {
+	if t.focus == NotificationPaneFocus {
 		t.app.UI.SetFocus(LeftPaneFocus)
 		t.focus = LeftPaneFocus
 		t.lastList = NotificationPaneFocus
@@ -185,10 +185,10 @@ func (t *StatusView) inputBoth(event *tcell.EventKey) {
 			t.end()
 		}
 	}
-	if len(t.feeds) > 0 && t.lastList == LeftPaneFocus {
+	if len(t.feeds) > 0 && t.focus == LeftPaneFocus {
 		feed := t.feeds[len(t.feeds)-1]
 		feed.Input(event)
-	} else if t.lastList == NotificationPaneFocus {
+	} else if t.focus == NotificationPaneFocus {
 		t.notificationView.feed.Input(event)
 	}
 }


### PR DESCRIPTION
A bug was present due to incorrect feed selection.
The bug can easily be reproduced:
- Open a feed
- Press 'n' to select the notifications and select any notification
- Press 't' to open the thread
- Select another message in the thread
- Press 'z'

Current behavior:
The original message from the notification is displayed

Expected behavior:
If a content warning is present, the full message is displayed; otherwise nothing happens.

This PR solves this bug