### PR TITLE
Pipe standard error of the editor

### DIFF
--- a/util.go
+++ b/util.go
@@ -97,6 +97,7 @@ func openEditor(app *tview.Application, content string) (string, error) {
 	cmd := exec.Command(editor, f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	var text []byte
 	app.Suspend(func() {
 		err = cmd.Run()


### PR DESCRIPTION
Some editors (e.g. [`vis`]) use standard error instead of standard output for drawing the UI.

[`vis`]: https://github.com/martanne/vis