### PR TITLE
Various visibility fixes

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -99,15 +99,12 @@ func showTootOptions(app *App, status *mastodon.Status, showSensitive bool) (str
 
 	head += reblogText
 
-	showedVisibility := false
+	head += fmt.Sprintf(special1+"(%s) ", status.Visibility)
 	if status.Account.DisplayName != "" {
-		showedVisibility = true
-		head += fmt.Sprintf(special1+"(%s) %s%s\n", status.Visibility, special2, status.Account.DisplayName)
-	}
-	if !showedVisibility {
-		head += fmt.Sprintf(special2+"(%s) %s%s\n\n", status.Visibility, special1, status.Account.Acct)
+		head += fmt.Sprintf("%s%s\n", special2, status.Account.DisplayName)
+		head += fmt.Sprintf("%s%s\n\n", special1, status.Account.Acct)
 	} else {
-		head += fmt.Sprintf(special1+"%s\n\n", status.Account.Acct)
+		head += fmt.Sprintf("%s%s\n\n", special2, status.Account.Acct)
 	}
 	output := head
 	content := stripped

--- a/feed.go
+++ b/feed.go
@@ -99,7 +99,9 @@ func showTootOptions(app *App, status *mastodon.Status, showSensitive bool) (str
 
 	head += reblogText
 
-	head += fmt.Sprintf(special1+"(%s) ", status.Visibility)
+	if status.Visibility != "public" {
+		head += fmt.Sprintf(special1+"(%s) ", status.Visibility)
+	}
 	if status.Account.DisplayName != "" {
 		head += fmt.Sprintf("%s%s\n", special2, status.Account.DisplayName)
 		head += fmt.Sprintf("%s%s\n\n", special1, status.Account.Acct)


### PR DESCRIPTION
* Streamline post visibility drawing logic, also fixes an issue where `special1` and `special2` were used inconsistently for users depending on whether they do or don't have a display name.
* Hide visibility of public posts. In my opinion it looks a bit cluttered.

Also, would be good to differentiate between private and follower-only posts as well as blocking boosting for them, but that's for another time.