### PR TITLE
Show links from non-mastodon instances

### DIFF
--- a/linkoverlay.go
+++ b/linkoverlay.go
@@ -48,20 +48,38 @@ type LinkOverlay struct {
 }
 
 func (l *LinkOverlay) SetLinks(urls []URL, status *mastodon.Status) {
+	realUrls := []URL{}
 	l.urls = []URL{}
 	l.mentions = []mastodon.Mention{}
 	l.tags = []mastodon.Tag{}
 
 	if urls != nil {
-		l.urls = urls
+		if status != nil {
+			for _, url := range urls {
+				isNotMention := true
+				for _, mention := range status.Mentions {
+					if mention.URL == url.URL {
+						isNotMention = false
+					}
+				}
+				if isNotMention {
+					realUrls = append(realUrls, url)
+				}
+			}
+
+		} else {
+			realUrls = urls
+		}
+		l.urls = realUrls
 	}
+
 	if status != nil {
 		l.mentions = status.Mentions
 		l.tags = status.Tags
 	}
 
 	l.List.Clear()
-	for _, url := range urls {
+	for _, url := range realUrls {
 		l.List.AddItem(url.Text, "", 0, nil)
 	}
 	for _, mention := range l.mentions {

--- a/util.go
+++ b/util.go
@@ -58,8 +58,8 @@ func getURLs(text string) []URL {
 						url.Text = a.Val
 					case "class":
 						url.Classes = strings.Split(a.Val, " ")
-						if strings.Contains(a.Val, "hashtag") ||
-							strings.Contains(a.Val, "mention") {
+
+						if strings.Contains(a.Val, "hashtag") {
 							appendUrl = false
 						}
 					}


### PR DESCRIPTION
This fixes #72 
Links from non-mastodon instances are classified as mentions for some reason and are completely undistinguishable from mentions.
Therefore i check the mentions in order to remove those from the links found in the toot.