### PR TITLE
Use /bin/sh to launch editor

### DIFF
--- a/util.go
+++ b/util.go
@@ -100,7 +100,7 @@ func openEditor(app *tview.Application, content string) (string, error) {
 			return "", err
 		}
 	}
-	cmd := exec.Command(editor, f.Name())
+	cmd := exec.Command("/bin/sh", "-c", editor + " " + f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
I'm not that familiar with go, but I've tested this fix for #95 locally and it seems to work as intended. I've hardcoded `"/bin/sh"` as I'm pretty confident that's guaranteed by POSIX to exist. It might need some quotes or escaping if there's a possibility that `f.Name()` includes spaces or other naughty characters.