### PR TITLE
Change section of "auto-load-newer" to "general"

### DIFF
--- a/config.go
+++ b/config.go
@@ -252,7 +252,7 @@ func parseStyle(cfg *ini.File) StyleConfig {
 func parseGeneral(cfg *ini.File) GeneralConfig {
 	general := GeneralConfig{}
 
-	general.AutoLoadNewer = cfg.Section("media").Key("auto-load-newer").MustBool(true)
+	general.AutoLoadNewer = cfg.Section("general").Key("auto-load-newer").MustBool(true)
 	autoLoadSeconds, err := cfg.Section("general").Key("auto-load-seconds").Int()
 	if err != nil {
 		autoLoadSeconds = 60


### PR DESCRIPTION
It is indicated by the name of the function, parseGeneral(), and the
general.AutoLoadNewer that "auto-load-newer" belongs to the "general"
section of the configuration file, not "media".