### PR TITLE
Pull boosted toot content from status.Reblog.Content

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -103,7 +103,11 @@ func showTootOptions(app *App, status *mastodon.Status, showSensitive bool) (str
 	var urls []URL
 	var u []URL
 
-	strippedContent, urls = cleanTootHTML(status.Content)
+	if status.Reblog != nil {
+		strippedContent, urls = cleanTootHTML(status.Reblog.Content)
+	} else {
+		strippedContent, urls = cleanTootHTML(status.Content)
+	}
 	strippedContent = tview.Escape(strippedContent)
 
 	toot := Toot{


### PR DESCRIPTION
After my mastodon instance moved to 3.5, I noticed boosted toots didn't have their content showing correctly. After some debugging I saw that boosted toot content wasn't coming with anything in `status.Content`, but rather the `status.Reblog.Content` property.

I only have the one mastodon account, so I can't test on non-mastodon 3.5 servers, but if you know of an open one I'm more than happy to test things there.