### PR TITLE
Added gruvbox-inspired theme

### DIFF
--- a/config/themes/gruvbox.ini
+++ b/config/themes/gruvbox.ini
@@ -1,0 +1,15 @@
+
+background=#1D2021
+text=#D4BE98
+subtle=#4271AE
+warning-text=#EA6962
+text-special-one=#D3869B
+text-special-two=#D3869B
+top-bar-background=#89B482
+top-bar-text=#1D2021
+status-bar-background=#A9B665
+status-bar-text=#D4BE98
+status-bar-view-background=#1D2021
+status-bar-view-text=#D4BE98
+list-selected-background=#1D2021
+list-selected-text=#7DAEA3


### PR DESCRIPTION
- Added a theme inspired by gruvbox. There is only one niggle that I can't get around, which is the line above the command line (i.e. the second line from the bottom). This has a very dissatisfying contrast ratio, but I can't figure out how to address this...