### PR TITLE
Update for Build it yourself documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ you will need Go. Use a newer one that supports modules.
 
 ```bash
 # Fetches and installs tut. Usally /home/user/go/bin
-go get -u github.com/RasmusLindroth/tut
+go install github.com/RasmusLindroth/tut@latest
 
 # You can also clone the repo if you like
 # First clone this repository


### PR DESCRIPTION
When I run `go get -u github.com/RasmusLindroth/tut`, I get this message:

```
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

This pr changes the command to `go install github.com/RasmusLindroth/tut@latest` instead.

My go version is `go version go1.19 linux/amd64`.
