### PR TITLE
Print error when failing to connect

### DIFF
--- a/auth/add.go
+++ b/auth/add.go
@@ -35,7 +35,7 @@ func AddAccount(ad *AccountData) *mastodon.Client {
 		})
 		_, err = client.GetInstance(context.Background())
 		if err != nil {
-			fmt.Printf("\nCouldn't connect to instance: %s\nTry again or press ^C.\n", server)
+			fmt.Printf("\nCouldn't connect to instance %s:\n%s\nTry again or press ^C.\n", server, err)
 			fmt.Println("--------------------------------------------------------------")
 		} else {
 			break


### PR DESCRIPTION
When setting up, network errors wouldn't print any useful information:

    Instance: bsd.network

    Couldn't connect to instance: https://bsd.network
    Try again or press ^C.

Now:

    Instance: bsd.network

    Couldn't connect to instance https://bsd.network:
    Get "https://bsd.network/api/v1/instance": x509: certificate signed by unknown authority
    Try again or press ^C.

(Turns out I didn't have root certificates installed.)