### PR TITLE
Ignore tut binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Makefile
 bin/
 TODO.md
+tut


### PR DESCRIPTION
When I do `go build .` it yields a `tut` file in the current directory that's not currently ignored.