### PR TITLE
Typo: upen -> open, sublte -> subtle in config

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -251,7 +251,7 @@ link-viewer=xdg-open
 link-terminal=false
 
 [open-custom]
-# This sections allows you to set up to five custom programs to upen URLs with.
+# This sections allows you to set up to five custom programs to open URLs with.
 # If the url points to an image, you can set c1-name to img and c1-use to imv.
 # If the program runs in a terminal and you want to run it in the same terminal
 # as tut. Set cX-terminal to true. The name will show up in the UI, so keep it
@@ -364,7 +364,7 @@ background=
 # default=
 text=
 
-# The color to display sublte elements or subtle text. Like lines and help text.
+# The color to display subtle elements or subtle text. Like lines and help text.
 # default=
 subtle=
 

--- a/config/default_config.go
+++ b/config/default_config.go
@@ -253,7 +253,7 @@ link-viewer=xdg-open
 link-terminal=false
 
 [open-custom]
-# This sections allows you to set up to five custom programs to upen URLs with.
+# This sections allows you to set up to five custom programs to open URLs with.
 # If the url points to an image, you can set c1-name to img and c1-use to imv.
 # If the program runs in a terminal and you want to run it in the same terminal
 # as tut. Set cX-terminal to true. The name will show up in the UI, so keep it
@@ -366,7 +366,7 @@ background=
 # default=
 text=
 
-# The color to display sublte elements or subtle text. Like lines and help text.
+# The color to display subtle elements or subtle text. Like lines and help text.
 # default=
 subtle=
 


### PR DESCRIPTION
Hi! Fixed some subtle :wink: typos while reading the config.