### PR TITLE
Make filter check case insensitive for non whole word filters

### DIFF
--- a/api/item.go
+++ b/api/item.go
@@ -117,11 +117,11 @@ func NewStatusItem(item *mastodon.Status, filters []*mastodon.Filter, timeline s
 				}
 			}
 		} else {
-			if strings.Contains(s.Content, strings.ToLower(f.Phrase)) {
+			if strings.Contains(strings.ToLower(s.Content), strings.ToLower(f.Phrase)) {
 				filtered.inUse = true
 				filtered.name = f.Phrase
 			}
-			if strings.Contains(s.SpoilerText, strings.ToLower(f.Phrase)) {
+			if strings.Contains(strings.ToLower(s.SpoilerText), strings.ToLower(f.Phrase)) {
 				filtered.inUse = true
 				filtered.name = f.Phrase
 			}


### PR DESCRIPTION
I noticed some statuses slipping through some of my filters. Looked into the code and it looks like the filter check is currently only case insensitive if the filter is a "whole word" filter. Non "whole word" filters are still checked in a case sensitive way.

It looks like all filters are treated case insensitive on the official web client, which makes me think tut's behavior is a bug. This is just a small change to fix that, which fixed the statuses that were previously slipping through for me.