### PR TITLE
WIP: Adding colours to the feed to indicate type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -195,9 +195,11 @@ type Style struct {
 
 	ListSelectedBackground tcell.Color
 	ListSelectedText       tcell.Color
+	ListSelectedBoldUnderline       int
 
 	ListSelectedInactiveBackground tcell.Color
 	ListSelectedInactiveText       tcell.Color
+	ListSelectedInactiveBoldUnderline       int
 
 	ControlsText      tcell.Color
 	ControlsHighlight tcell.Color
@@ -217,6 +219,11 @@ type Style struct {
 	IconColor tcell.Color
 
 	CommandText tcell.Color
+
+    DateTimeText  tcell.Color
+    BoostText  tcell.Color
+    MediaText  tcell.Color
+    CardText  tcell.Color
 }
 
 type Media struct {
@@ -596,6 +603,8 @@ func parseStyle(cfg *ini.File, cnfPath string, cnfDir string) Style {
 		s = tcfg.Section("").Key("list-selected-text").String()
 		style.ListSelectedText = tcell.GetColor(s)
 
+		style.ListSelectedBoldUnderline = tcfg.Section("").Key("list-selected-boldunderline").MustInt(0)
+
 		s = tcfg.Section("").Key("list-selected-inactive-background").String()
 		if len(s) > 0 {
 			style.ListSelectedInactiveBackground = tcell.GetColor(s)
@@ -685,6 +694,30 @@ func parseStyle(cfg *ini.File, cnfPath string, cnfDir string) Style {
 		} else {
 			style.CommandText = style.StatusBarText
 		}
+		s = tcfg.Section("").Key("datetime-text").String()
+		if len(s) > 0 {
+			style.DateTimeText = tcell.GetColor(s)
+		} else {
+			style.DateTimeText = style.Subtle
+		}
+		s = tcfg.Section("").Key("boost-text").String()
+		if len(s) > 0 {
+			style.BoostText = tcell.GetColor(s)
+		} else {
+			style.BoostText = style.Text
+		}
+		s = tcfg.Section("").Key("media-text").String()
+		if len(s) > 0 {
+			style.MediaText = tcell.GetColor(s)
+		} else {
+			style.MediaText = style.Text
+		}
+		s = tcfg.Section("").Key("card-text").String()
+		if len(s) > 0 {
+			style.CardText = tcell.GetColor(s)
+		} else {
+			style.CardText = style.Text
+		}
 	} else {
 		s := cfg.Section("style").Key("background").String()
 		style.Background = parseColor(s, "#27822", xrdbColors)
@@ -727,6 +760,8 @@ func parseStyle(cfg *ini.File, cnfPath string, cnfDir string) Style {
 
 		s = cfg.Section("style").Key("list-selected-text").String()
 		style.ListSelectedText = parseColor(s, "white", xrdbColors)
+
+		style.ListSelectedBoldUnderline = cfg.Section("style").Key("list-selected-boldunderline").MustInt(0)
 
 		s = cfg.Section("style").Key("list-selected-inactive-background").String()
 		if len(s) > 0 {
@@ -810,6 +845,30 @@ func parseStyle(cfg *ini.File, cnfPath string, cnfDir string) Style {
 			style.CommandText = parseColor(s, "white", xrdbColors)
 		} else {
 			style.CommandText = style.StatusBarText
+		}
+        s = cfg.Section("style").Key("datetime-text").String()
+		if len(s) > 0 {
+			style.DateTimeText = parseColor(s, "#808080", xrdbColors)
+		} else {
+			style.DateTimeText = style.Subtle
+		}
+		s = cfg.Section("style").Key("boost-text").String()
+		if len(s) > 0 {
+			style.BoostText = parseColor(s, "white", xrdbColors)
+		} else {
+			style.BoostText = style.Text
+		}
+		s = cfg.Section("style").Key("media-text").String()
+		if len(s) > 0 {
+			style.MediaText = parseColor(s, "white", xrdbColors)
+		} else {
+			style.MediaText = style.Text
+		}
+		s = cfg.Section("style").Key("card-text").String()
+		if len(s) > 0 {
+			style.CardText = parseColor(s, "white", xrdbColors)
+		} else {
+			style.CardText = style.Text
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -158,6 +158,8 @@ type General struct {
 	ContentProportion   int
 	TerminalTitle       int
 	ShowIcons           bool
+	SymbolWidth         int
+	SymbolFormat        string
 	ShowHelp            bool
 	RedrawUI            bool
 	LeaderKey           rune
@@ -844,6 +846,9 @@ func parseGeneral(cfg *ini.File) General {
 	general.ShortHints = cfg.Section("general").Key("short-hints").MustBool(false)
 	general.ShowFilterPhrase = cfg.Section("general").Key("show-filter-phrase").MustBool(true)
 	general.ShowIcons = cfg.Section("general").Key("show-icons").MustBool(true)
+	general.SymbolWidth = cfg.Section("general").Key("symbol-width").MustInt(6)
+	symbolFormat := "%" + fmt.Sprintf("%d", general.SymbolWidth) + "s"
+	general.SymbolFormat = cfg.Section("general").Key("symbol-format").MustString(symbolFormat)
 	general.ShowHelp = cfg.Section("general").Key("show-help").MustBool(true)
 	general.RedrawUI = cfg.Section("general").Key("redraw-ui").MustBool(true)
 	general.StickToTop = cfg.Section("general").Key("stick-to-top").MustBool(false)

--- a/config/default_config.go
+++ b/config/default_config.go
@@ -391,6 +391,8 @@ background=
 # default=
 text=
 
+
+
 # The color to display subtle elements or subtle text. Like lines and help text.
 # default=
 subtle=
@@ -492,6 +494,18 @@ timeline-name-background=
 # The text color on named timelines
 # default=
 timeline-name-text=
+
+# The text color used for date/time in the timeline view 
+# defaults to the same color as subtle
+datetime-text=
+
+# The text color used for boosts in the timeline view 
+# defaults to the primary text color
+boost-text=
+
+# The text color used for toots with media or cards in the timeline view 
+# defaults to the primary text color
+media-text=
 
 [input]
 # You can edit the keys for tut below.

--- a/ui/composeview.go
+++ b/ui/composeview.go
@@ -510,7 +510,7 @@ func NewMediaList(tv *TutView) *MediaList {
 		tutView: tv,
 		heading: NewTextView(tv.tut.Config),
 		text:    NewTextView(tv.tut.Config),
-		list:    NewList(tv.tut.Config),
+		list:    NewList(tv.tut.Config, false),
 	}
 	ml.scrollSleep = NewScrollSleep(ml.Next, ml.Prev)
 	ml.heading.SetText(fmt.Sprintf("Media files: %d", ml.list.GetItemCount()))

--- a/ui/feed.go
+++ b/ui/feed.go
@@ -28,8 +28,13 @@ func (fl *FeedList) InFocus(style config.Style) {
 func inFocus(l *tview.List, style config.Style) {
 	l.SetBackgroundColor(style.Background)
 	l.SetMainTextColor(style.Text)
-	l.SetSelectedBackgroundColor(style.ListSelectedBackground)
-	l.SetSelectedTextColor(style.ListSelectedText)
+    l.SetSelectedTextColor(style.ListSelectedText)
+    if style.ListSelectedBoldUnderline == 1 {
+        s := tcell.Style.Attributes(tcell.Style{}, tcell.AttrBold | tcell.AttrUnderline)
+        l.SetSelectedStyle(s)
+    } else {
+        l.SetSelectedBackgroundColor(style.ListSelectedBackground)
+    }
 }
 
 func (fl *FeedList) OutFocus(style config.Style) {
@@ -40,8 +45,13 @@ func (fl *FeedList) OutFocus(style config.Style) {
 func outFocus(l *tview.List, style config.Style) {
 	l.SetBackgroundColor(style.Background)
 	l.SetMainTextColor(style.Text)
-	l.SetSelectedBackgroundColor(style.ListSelectedInactiveBackground)
-	l.SetSelectedTextColor(style.ListSelectedInactiveText)
+    l.SetSelectedTextColor(style.ListSelectedInactiveText)
+    if style.ListSelectedBoldUnderline == 1 {
+        s := tcell.Style.Attributes(tcell.Style{}, tcell.AttrBold)
+        l.SetSelectedStyle(s)
+    } else {
+        l.SetSelectedBackgroundColor(style.ListSelectedInactiveBackground)
+    }
 }
 
 type Feed struct {
@@ -513,8 +523,8 @@ func NewFollowRequests(tv *TutView) *Feed {
 
 func NewFeedList(t *Tut, stickyCount int) *FeedList {
 	fl := &FeedList{
-		Text:        NewList(t.Config),
-		Symbol:      NewList(t.Config),
+		Text:        NewList(t.Config, true),
+		Symbol:      NewList(t.Config, true),
 		stickyCount: stickyCount,
 	}
 	return fl

--- a/ui/item.go
+++ b/ui/item.go
@@ -17,10 +17,12 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 	case api.StatusType:
 		s := item.Raw().(*mastodon.Status)
 		symbol := ""
+        textcolor := cfg.Style.Text
 		status := s
 		if s.Reblog != nil {
 			status = s.Reblog
 			symbol += "♺ "
+            textcolor = cfg.Style.BoostText
 		}
 		if item.Pinned() {
 			symbol += "! "
@@ -38,9 +40,13 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 			symbol += "⚑ "
 		}
 		if len(s.MediaAttachments) > 0 {
+            textcolor = cfg.Style.MediaText
 			symbol += "⚭ "
 		}
 		if s.Card != nil {
+		    if len(s.MediaAttachments) == 0 {
+                textcolor = cfg.Style.CardText
+            }
 			symbol += "⚯  "
 		}
 		if status.RepliesCount > 0 {
@@ -57,12 +63,12 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 		if symbol != "" {
 			symbol = fmt.Sprintf(cfg.General.SymbolFormat, symbol)
 		}
-		return fmt.Sprintf("%s %s", d, acc), symbol
+		return fmt.Sprintf("[#%06x]%s[#%06x] %s",cfg.Style.DateTimeText.Hex(), d, textcolor.Hex() , acc), symbol
 	case api.StatusHistoryType:
 		s := item.Raw().(*mastodon.StatusHistory)
 		acc := strings.TrimSpace(s.Account.Acct)
 		d := OutputDate(cfg, s.CreatedAt.Local())
-		return fmt.Sprintf("%s %s", d, acc), ""
+		return fmt.Sprintf("[#%06x]%s[#%06x] %s",cfg.Style.DateTimeText.Hex(), d, cfg.Style.Text.Hex() , acc), ""
 	case api.UserType:
 		a := item.Raw().(*api.User)
 		return strings.TrimSpace(a.Data.Acct), ""
@@ -91,7 +97,7 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 			symbol = fmt.Sprintf(cfg.General.SymbolFormat, symbol)
 		}
 		d := OutputDate(cfg, a.Item.CreatedAt.Local())
-		return fmt.Sprintf("%s %s", d, strings.TrimSpace(a.Item.Account.Acct)), symbol
+		return fmt.Sprintf("[#%06x]%s[#%06x] %s",cfg.Style.DateTimeText.Hex(), d, cfg.Style.Text.Hex() , strings.TrimSpace(a.Item.Account.Acct)), symbol
 	case api.ListsType:
 		a := item.Raw().(*mastodon.List)
 		return tview.Escape(a.Title), ""

--- a/ui/item.go
+++ b/ui/item.go
@@ -20,12 +20,31 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 		status := s
 		if s.Reblog != nil {
 			status = s.Reblog
-		}
-		if status.RepliesCount > 0 {
-			symbol = " ⤶ "
+			symbol += "♺ "
 		}
 		if item.Pinned() {
-			symbol = " ! "
+			symbol += "! "
+		}
+		if s.Bookmarked {
+			symbol += "☜  "
+		}
+		if s.Favourited {
+			symbol += "★ "
+		}
+		if s.Poll != nil {
+			symbol += "= "
+		}
+		if s.Sensitive || s.SpoilerText != "" {
+			symbol += "⚑ "
+		}
+		if len(s.MediaAttachments) > 0 {
+			symbol += "⚭ "
+		}
+		if s.Card != nil {
+			symbol += "⚯  "
+		}
+		if status.RepliesCount > 0 {
+			symbol += "⤷ "
 		}
 		acc := strings.TrimSpace(s.Account.Acct)
 		if cfg.General.ShowBoostedUser && s.Reblog != nil {
@@ -35,6 +54,9 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 			acc = fmt.Sprintf("♺ %s", acc)
 		}
 		d := OutputDate(cfg, s.CreatedAt.Local())
+		if symbol != "" {
+			symbol = fmt.Sprintf(cfg.General.SymbolFormat, symbol)
+		}
 		return fmt.Sprintf("%s %s", d, acc), symbol
 	case api.StatusHistoryType:
 		s := item.Raw().(*mastodon.StatusHistory)
@@ -51,19 +73,22 @@ func DrawListItem(cfg *config.Config, item api.Item) (string, string) {
 		symbol := ""
 		switch a.Item.Type {
 		case "follow", "follow_request":
-			symbol += " + "
+			symbol += "+ "
 		case "favourite":
-			symbol = " ★ "
+			symbol = "★ "
 		case "reblog":
-			symbol = " ♺ "
+			symbol = "♺ "
 		case "mention":
-			symbol = " ⤶ "
+			symbol = "⤶ "
 		case "update":
-			symbol = " ☢ "
+			symbol = "☢ "
 		case "poll":
-			symbol = " = "
+			symbol = "= "
 		case "status":
-			symbol = " ⤶ "
+			symbol = "⤶ "
+		}
+		if symbol != "" {
+			symbol = fmt.Sprintf(cfg.General.SymbolFormat, symbol)
 		}
 		d := OutputDate(cfg, a.Item.CreatedAt.Local())
 		return fmt.Sprintf("%s %s", d, strings.TrimSpace(a.Item.Account.Acct)), symbol

--- a/ui/linkview.go
+++ b/ui/linkview.go
@@ -17,7 +17,7 @@ type LinkView struct {
 }
 
 func NewLinkView(tv *TutView) *LinkView {
-	l := NewList(tv.tut.Config)
+	l := NewList(tv.tut.Config, false)
 	c := NewControlView(tv.tut.Config)
 	lv := &LinkView{
 		tutView:  tv,

--- a/ui/loginview.go
+++ b/ui/loginview.go
@@ -17,7 +17,7 @@ type LoginView struct {
 
 func NewLoginView(tv *TutView, accs *auth.AccountData) *LoginView {
 	tv.Shared.Top.SetText("select account")
-	list := NewList(tv.tut.Config)
+	list := NewList(tv.tut.Config, false)
 	for _, a := range accs.Accounts {
 		list.AddItem(fmt.Sprintf("%s - %s", a.Name, a.Server), "", 0, nil)
 	}

--- a/ui/mainview.go
+++ b/ui/mainview.go
@@ -31,7 +31,7 @@ func (mv *MainView) ForceUpdate() {
 }
 
 func feedList(mv *TutView, fh *FeedHolder) *tview.Flex {
-	iw := 3
+	iw := mv.tut.Config.General.SymbolWidth
 	if !mv.tut.Config.General.ShowIcons {
 		iw = 0
 	}

--- a/ui/pollview.go
+++ b/ui/pollview.go
@@ -47,7 +47,7 @@ func NewPollView(tv *TutView) *PollView {
 		info:       NewTextView(tv.tut.Config),
 		expiration: NewDropDown(tv.tut.Config),
 		controls:   NewControlView(tv.tut.Config),
-		list:       NewList(tv.tut.Config),
+		list:       NewList(tv.tut.Config, false),
 	}
 	p.scrollSleep = NewScrollSleep(p.Next, p.Prev)
 	p.Reset()

--- a/ui/preferenceview.go
+++ b/ui/preferenceview.go
@@ -40,7 +40,7 @@ func NewPreferenceView(tv *TutView) *PreferenceView {
 		shared:      tv.Shared,
 		displayName: NewTextView(tv.tut.Config),
 		bio:         NewTextView(tv.tut.Config),
-		fields:      NewList(tv.tut.Config),
+		fields:      NewList(tv.tut.Config, false),
 		visibility:  NewDropDown(tv.tut.Config),
 		controls:    NewControlView(tv.tut.Config),
 		preferences: &preferences{},

--- a/ui/styled_elements.go
+++ b/ui/styled_elements.go
@@ -56,13 +56,19 @@ func NewControlButton(tv *TutView, control Control) *tview.Button {
 	return btn
 }
 
-func NewList(cnf *config.Config) *tview.List {
+func NewList(cnf *config.Config, is_feed bool) *tview.List {
 	l := tview.NewList()
 	l.ShowSecondaryText(false)
 	l.SetHighlightFullLine(true)
 	l.SetBackgroundColor(cnf.Style.Background)
 	l.SetMainTextColor(cnf.Style.Text)
-	l.SetSelectedBackgroundColor(cnf.Style.ListSelectedBackground)
+    if is_feed && cnf.Style.ListSelectedBoldUnderline == 1 {
+        l.SetSelectedBackgroundColor(cnf.Style.ListSelectedBackground)
+        s := tcell.Style.Attributes(tcell.Style{}, tcell.AttrBold | tcell.AttrUnderline)
+        l.SetSelectedStyle(s)
+    } else {
+        l.SetSelectedBackgroundColor(cnf.Style.Background)
+    }
 	l.SetSelectedTextColor(cnf.Style.ListSelectedText)
 	return l
 }

--- a/ui/voteview.go
+++ b/ui/voteview.go
@@ -25,7 +25,7 @@ func NewVoteView(tv *TutView) *VoteView {
 		shared:   tv.Shared,
 		textTop:  NewTextView(tv.tut.Config),
 		controls: NewControlView(tv.tut.Config),
-		list:     NewList(tv.tut.Config),
+		list:     NewList(tv.tut.Config, false),
 	}
 	v.scrollSleep = NewScrollSleep(v.Next, v.Prev)
 	v.View = voteViewUI(v)


### PR DESCRIPTION
This is a continuation on top of #218  (and includes it) , I'm adding support for colours to indicate toot types, but to maintain readability I needed to find an alternative selection method than setting a background colour, so I implemented one (opt-in) that makes the selected item bold and also underlines when on the focussed pane.

This still needs some fine-tuning. Screenshot of how it can look:

![tut_timeline_colors](https://user-images.githubusercontent.com/75427/208549729-2f05aea2-a4c7-41b1-ac9e-8712c8cf5710.png)
