### PR TITLE
Use /bin/sh to launch editor (proper shell quoting for editor)

### DIFF
--- a/ui/open.go
+++ b/ui/open.go
@@ -85,12 +85,6 @@ func OpenEditor(tv *TutView, content string) (string, error) {
 	} else {
 		editor = strings.TrimSpace(tv.tut.Config.General.Editor)
 	}
-	args := []string{}
-	parts := strings.Split(editor, " ")
-	if len(parts) > 1 {
-		args = append(args, parts[1:]...)
-		editor = parts[0]
-	}
 	f, err := os.CreateTemp("", "tut")
 	if err != nil {
 		return "", err
@@ -102,7 +96,6 @@ func OpenEditor(tv *TutView, content string) (string, error) {
 		}
 	}
 	fname := f.Name()
-	args = append(args, fname)
 	f.Close()
 	cmd := exec.Command("/bin/sh", "-c", editor + " " + f.Name())
 	cmd.Stdin = os.Stdin

--- a/ui/open.go
+++ b/ui/open.go
@@ -104,7 +104,7 @@ func OpenEditor(tv *TutView, content string) (string, error) {
 	fname := f.Name()
 	args = append(args, fname)
 	f.Close()
-	cmd := exec.Command(editor, args...)
+	cmd := exec.Command("/bin/sh", "-c", editor + " " + f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
> https://github.com/RasmusLindroth/tut/pull/96#issuecomment-950148821
> 
> > I solved it in another way, but thank you for the pull request :)
> 
> @RasmusLindroth Your solution (assuming [here](https://github.com/RasmusLindroth/tut/commit/0e6d4abcaadd0d432362046f4d3bf6af8e779255#diff-3a710ab6a1dd3264a76a1e4c4c3ebcee14762ef3a66f707726e17fd5fa255715R94)) does it wrong when having to deal with escaped characters (spaces). Probably better to leave it up to the shell than do it yourself in a way that doesn't work for all.
> 
> Because my neovim config does stuff I don't want for composing toots, I have do `:set tw=0` every time I open the editor. I had an idea, it's to do `nvim -c ":set tw=0"` but tut interprets the space between `set` and `tw=0` to be a separate argument, basically making it impossible for my solution to work.
> 
> https://github.com/RasmusLindroth/tut/blob/33d7cd8cbf5f8048b49bf218a3c7aed2ab3d6346/ui/open.go#L89

That was my somewhat ranty rant. This PR is pretty much [this](https://github.com/RasmusLindroth/tut/pull/96) but rebased so that it works on the master branch.

Also, I tested it, now my thing works. I'm not sure of other scenarios where it doesn't work (or works against the user).

(Questions welcome, although you should read the quoted text for rationale. I am sending this in quite a hurry because I already lost a previous version of my comment, it's nearly midnight and i'm kinda annoyed, so let me know of any little imperfections)