### PR TITLE
Allow the original page of a status to be opened

### DIFF
--- a/api/item.go
+++ b/api/item.go
@@ -67,6 +67,15 @@ func getUrlsStatus(status *mastodon.Status) ([]util.URL, []mastodon.Mention, []m
 		}
 	}
 
+	// Also append the URL of the actual status, in case the user wants to open
+	// that. This is equivalent to "open original page" in the Mastodon web
+	// interface.
+	realUrls = append(realUrls, util.URL{
+		Text:    status.URL + " (original page)",
+		URL:     status.URL,
+		Classes: []string{},
+	})
+
 	length := len(realUrls) + len(status.Mentions) + len(status.Tags)
 	return realUrls, status.Mentions, status.Tags, length
 }


### PR DESCRIPTION
This adds a link when the "open" option is selected for a status that matches the "open original page" overflow menu item for a status in the Mastodon web UI.