### PR TITLE
feat(search): Add general-purpose :search command

### DIFF
--- a/api/feed.go
+++ b/api/feed.go
@@ -198,6 +198,45 @@ func (ac *AccountClient) GetUsers(search string) ([]Item, error) {
 	return items, nil
 }
 
+func (ac *AccountClient) GetSearch(query string) ([]Item, error) {
+	var items []Item
+	res, err := ac.Client.Search(context.Background(), query, true)
+	if err != nil {
+		return items, err
+	}
+	if len(res.Accounts) > 0 {
+		ids := make([]string, len(res.Accounts))
+		for i, a := range res.Accounts {
+			ids[i] = string(a.ID)
+		}
+		rel, err := ac.Client.GetAccountRelationships(context.Background(), ids)
+		if err != nil {
+			return items, err
+		}
+		relMap := make(map[mastodon.ID]*mastodon.Relationship, len(rel))
+		for _, r := range rel {
+			relMap[r.ID] = r
+		}
+		for _, a := range res.Accounts {
+			r := relMap[a.ID]
+			if r == nil {
+				r = &mastodon.Relationship{ID: a.ID}
+			}
+			items = append(items, NewUserItem(&User{
+				Data:     a,
+				Relation: r,
+			}, false))
+		}
+	}
+	for _, s := range res.Statuses {
+		items = append(items, NewStatusItem(s, false))
+	}
+	for _, t := range res.Hashtags {
+		items = append(items, NewTagItem(t))
+	}
+	return items, nil
+}
+
 func (ac *AccountClient) GetBoostsStatus(pg *mastodon.Pagination, id mastodon.ID) ([]Item, error) {
 	fn := func() ([]*mastodon.Account, error) {
 		return ac.Client.GetRebloggedBy(context.Background(), id, pg)

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ const (
 	List
 	ListUsersIn
 	ListUsersAdd
+	Search
 )
 
 type NotificationToHide string
@@ -999,6 +1000,9 @@ func parseGeneral(cfg GeneralTOML) General {
 				tl.FeedType = Lists
 			case "tag":
 				tl.FeedType = Tag
+				tl.Subaction = NilDefaultString(l.Data, sp(""))
+			case "search":
+				tl.FeedType = Search
 				tl.Subaction = NilDefaultString(l.Data, sp(""))
 			default:
 				fmt.Printf("timeline %s is invalid\n", *l.Type)

--- a/config/help.tmpl
+++ b/config/help.tmpl
@@ -131,6 +131,9 @@ Here's a list of supported commands.
 {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}:saved{{ Flags "-" }}{{ Color .Style.Text }}
     Alias for bookmarks
 
+{{ Color .Style.TextSpecial2 }}{{ Flags "b" }}:search{{ Flags "-" }}{{ Color .Style.Text }} [query]
+    Open a search box, or search directly if a query is given. Accepts handles, URLs to profiles/posts, and hashtags. Results are shown in a new pane.
+
 {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}:stick-to-top{{ Flags "-" }}{{ Color .Style.Text }}
     Toggle the stick-to-top setting that always shows the latest toot in all timelines
 

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -984,6 +984,22 @@ func NewUserSearch(ac *api.AccountClient, cnf *config.Config, search string) *Fe
 	return feed
 }
 
+func NewSearch(ac *api.AccountClient, cnf *config.Config, query string) *Feed {
+	feed := newFeed(ac, config.Search, cnf, false, false)
+	feed.name = query
+	once := true
+	feed.loadNewer = func() {
+		if once {
+			feed.normalEmpty(func() ([]api.Item, error) {
+				return ac.GetSearch(query)
+			})
+		}
+		once = false
+	}
+
+	return feed
+}
+
 func NewUserProfile(ac *api.AccountClient, cnf *config.Config, user *api.User) *Feed {
 	feed := newFeed(ac, config.User, cnf, false, false)
 	feed.name = user.Data.Acct

--- a/ui/cmdbar.go
+++ b/ui/cmdbar.go
@@ -79,6 +79,19 @@ func (c *CmdBar) DoneFunc(key tcell.Key) {
 	case ":bookmarks", ":saved":
 		c.tutView.BookmarksCommand()
 		c.Back()
+	case ":search":
+		if len(parts) < 2 {
+			c.tutView.PageFocus = MainFocus
+			c.tutView.SetPage(SearchFocus)
+			c.ClearInput()
+			c.View.Autocomplete()
+			break
+		}
+		query := strings.TrimSpace(strings.Join(parts[1:], " "))
+		if len(query) > 0 {
+			c.tutView.SearchCommand(query)
+		}
+		c.Back()
 	case ":favorited":
 		c.tutView.FavoritedCommand()
 		c.Back()
@@ -294,7 +307,7 @@ func (c *CmdBar) DoneFunc(key tcell.Key) {
 
 func (c *CmdBar) Autocomplete(curr string) []string {
 	var entries []string
-	words := strings.Split(":blocking,:boosts,:bookmarks,:clear-notifications,:clear-temp,:close-pane,:compose,:favorites,:favorited,:follow-tag,:followers,:following,:help,:h,:history,:move-pane,:next-acct,:lists,:list-placement,:list-split,:login,:muting,:newer,:preferences,:prev-acct,:profile,:proportions,:refetch,:requests,:saved,:stick-to-top,:tag,:timeline,:tl,:unfollow-tag,:user,:pane,:quit,:q", ",")
+	words := strings.Split(":blocking,:boosts,:bookmarks,:clear-notifications,:clear-temp,:close-pane,:compose,:favorites,:favorited,:follow-tag,:followers,:following,:help,:h,:history,:move-pane,:next-acct,:lists,:list-placement,:list-split,:login,:muting,:newer,:preferences,:prev-acct,:profile,:proportions,:refetch,:requests,:saved,:search,:stick-to-top,:tag,:timeline,:tl,:unfollow-tag,:user,:pane,:quit,:q", ",")
 	if curr == "" {
 		return entries
 	}

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -145,6 +145,15 @@ func (tv *TutView) TagCommand(tag string) {
 		tv.tut.Config.General.CommandsInNewPane)
 }
 
+func (tv *TutView) SearchCommand(query string) {
+	tv.Timeline.AddFeed(
+		NewSearchFeed(tv, config.NewTimeline(config.Timeline{
+			FeedType:  config.Search,
+			Subaction: query,
+		})),
+		tv.tut.Config.General.CommandsInNewPane)
+}
+
 func (tv *TutView) TagsCommand() {
 	tv.Timeline.AddFeed(
 		NewTagsFeed(tv, config.NewTimeline(config.Timeline{

--- a/ui/feed.go
+++ b/ui/feed.go
@@ -327,6 +327,25 @@ func NewUserSearchFeed(tv *TutView, tl *config.Timeline) *Feed {
 	return fd
 }
 
+func NewSearchFeed(tv *TutView, tl *config.Timeline) *Feed {
+	f := feed.NewSearch(tv.tut.Client, tv.tut.Config, tl.Subaction)
+	f.LoadNewer()
+	fd := &Feed{
+		tutView:  tv,
+		Data:     f,
+		List:     NewFeedList(tv.tut, f.StickyCount()),
+		Content:  NewFeedContent(tv.tut),
+		Timeline: tl,
+	}
+	for _, s := range f.List() {
+		main, symbol := DrawListItem(tv.tut.Config, s)
+		fd.List.AddItem(main, symbol, s.ID())
+	}
+	fd.DrawContent()
+
+	return fd
+}
+
 func NewTagFeed(tv *TutView, tl *config.Timeline) *Feed {
 	f := feed.NewTag(tv.tut.Client, tv.tut.Config, tl.Subaction, tl.HideBoosts, tl.HideReplies)
 	f.LoadNewer()

--- a/ui/input.go
+++ b/ui/input.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (tv *TutView) Input(event *tcell.EventKey) *tcell.EventKey {
-	if tv.PageFocus != LoginFocus {
+	if tv.PageFocus != LoginFocus && tv.PageFocus != SearchFocus {
 		switch event.Rune() {
 		case ':':
 			tv.SetPage(CmdFocus)
@@ -23,11 +23,15 @@ func (tv *TutView) Input(event *tcell.EventKey) *tcell.EventKey {
 			tv.SetPage(HelpFocus)
 		}
 	}
-	if tv.PageFocus != LoginFocus && tv.PageFocus != CmdFocus {
+	if tv.PageFocus != LoginFocus && tv.PageFocus != CmdFocus && tv.PageFocus != SearchFocus {
 		event = tv.InputLeaderKey(event)
 		if event == nil {
 			return nil
 		}
+	}
+
+	if tv.PageFocus == SearchFocus {
+		return event
 	}
 
 	if tv.tut.Config.Input.MainNextAccount.Match(event.Key(), event.Rune()) {
@@ -66,6 +70,8 @@ func (tv *TutView) Input(event *tcell.EventKey) *tcell.EventKey {
 		return tv.InputPreference(event)
 	case EditorFocus:
 		return tv.InputEditorView(event)
+	case SearchFocus:
+		return event
 	default:
 		return event
 	}

--- a/ui/search.go
+++ b/ui/search.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type SearchView struct {
+	tutView *TutView
+	View    *tview.Flex
+	Input   *tview.InputField
+}
+
+func NewSearchView(tv *TutView) *SearchView {
+	input := NewInputField(tv.tut.Config)
+	input.SetLabel("Search: ")
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			query := strings.TrimSpace(input.GetText())
+			if len(query) > 0 {
+				tv.SearchCommand(query)
+			}
+		}
+		tv.FocusMainNoHistory()
+		input.SetText("")
+	})
+
+	flex := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(input, 1, 0, true).
+		AddItem(nil, 0, 1, false)
+	flex.SetBackgroundColor(tv.tut.Config.Style.Background)
+
+	sv := &SearchView{
+		tutView: tv,
+		View:    flex,
+		Input:   input,
+	}
+	return sv
+}

--- a/ui/timeline.go
+++ b/ui/timeline.go
@@ -61,6 +61,8 @@ func CreateFeed(tv *TutView, f *config.Timeline) *Feed {
 		nf = NewListsFeed(tv, f)
 	case config.Tag:
 		nf = NewTagFeed(tv, f)
+	case config.Search:
+		nf = NewSearchFeed(tv, f)
 	default:
 		fmt.Println("Invalid feed")
 		tv.CleanExit(1)
@@ -126,6 +128,8 @@ func (tl *Timeline) AddFeed(f *Feed, newPane bool) {
 		case config.User:
 			f.Timeline.Name = fmt.Sprintf("@%s", name)
 		case config.UserList:
+			f.Timeline.Name = fmt.Sprintf("Search %s", name)
+		case config.Search:
 			f.Timeline.Name = fmt.Sprintf("Search %s", name)
 		case config.Conversations:
 			f.Timeline.Name = "Direct"
@@ -345,6 +349,8 @@ func (tl *Timeline) GetTitle() string {
 		ct = fmt.Sprintf("user %s", name)
 	case config.UserList:
 		ct = fmt.Sprintf("user search %s", name)
+	case config.Search:
+		ct = fmt.Sprintf("search %s", name)
 	case config.Conversations:
 		ct = "direct"
 	case config.Lists:

--- a/ui/tutview.go
+++ b/ui/tutview.go
@@ -71,6 +71,7 @@ type TutView struct {
 	HelpView       *HelpView
 	EditorView     *EditorView
 	ModalView      *ModalView
+	SearchView     *SearchView
 
 	FileList []string
 }
@@ -257,6 +258,7 @@ func (tv *TutView) loggedIn(acc auth.Account) {
 	tv.HelpView = NewHelpView(tv)
 	tv.EditorView = NewEditorView(tv)
 	tv.ModalView = NewModalView(tv)
+	tv.SearchView = NewSearchView(tv)
 
 	tv.View.AddPage("main", tv.MainView.View, true, false)
 	tv.View.AddPage("link", tv.LinkView.View, true, false)
@@ -267,6 +269,7 @@ func (tv *TutView) loggedIn(acc auth.Account) {
 	tv.View.AddPage("poll", tv.PollView.View, true, false)
 	tv.View.AddPage("preference", tv.PreferenceView.View, true, false)
 	tv.View.AddPage("modal", tv.ModalView.View, true, false)
+	tv.View.AddPage("search", tv.SearchView.View, true, false)
 	tv.SetPage(MainFocus)
 }
 

--- a/ui/view.go
+++ b/ui/view.go
@@ -24,6 +24,7 @@ const (
 	EditorFocus
 	PollFocus
 	PreferenceFocus
+	SearchFocus
 )
 
 func (tv *TutView) GetCurrentFeed() *Feed {
@@ -160,6 +161,11 @@ func (tv *TutView) SetPage(f PageFocusAt) {
 		tv.tut.App.SetFocus(tv.View)
 		tv.Shared.Bottom.StatusBar.SetMode(PreferenceMode)
 		tv.Shared.Top.SetText("preferences")
+	case SearchFocus:
+		tv.PageFocus = SearchFocus
+		tv.View.SwitchToPage("search")
+		tv.Shared.Bottom.StatusBar.SetMode(CmdMode)
+		tv.tut.App.SetFocus(tv.SearchView.Input)
 	}
 	tv.ShouldSync()
 }


### PR DESCRIPTION
Adds a search modal and `:search` command that accepts handles, federated URLs, or free-form queries and displays mixed results (accounts, statuses, hashtags) in a new timeline pane.