### PR TITLE
feat(ui): add vi-style in-pane search with / and n/N navigation

### DIFF
--- a/config/help.tmpl
+++ b/config/help.tmpl
@@ -20,6 +20,12 @@ Explanation of the non obvious keys when viewing a toot
     {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}o{{ Flags "-" }}{{ Color .Style.Text }} - open. Gives you a list of all URLs in the toot. Opens them in your default browser, if it's an user or tag they will be opened in tut
     {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}m{{ Flags "-" }}{{ Color .Style.Text }} - media. Opens the media with xdg-open
 
+{{ Color .Style.Text }}{{ Flags "b" }}Search{{ Flags "-" }}
+
+    {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}/{{ Flags "-" }}{{ Color .Style.Text }}<search-term> - Search for toots, users, or other items in the current pane. Press {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}Enter{{ Flags "-" }}{{ Color .Style.Text }} to run the search.
+    {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}n{{ Flags "-" }}{{ Color .Style.Text }} - Go to the next match
+    {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}N{{ Flags "-" }}{{ Color .Style.Text }} - Go to the previous match
+
 {{ Color .Style.Text }}{{ Flags "b" }}Commands{{ Flags "-" }}
 
 All commands start with {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}:{{ Flags "-" }}{{ Color .Style.Text }}. And you run the command by hitting {{ Color .Style.TextSpecial2 }}{{ Flags "b" }}Enter{{ Flags "-" }}{{ Color .Style.Text }}.

--- a/docs/man/tut.7.md
+++ b/docs/man/tut.7.md
@@ -28,6 +28,12 @@ To change the keys look at tut(5) under the *INPUT* section.
 **o** = open. Gives you a list of all URLs in the toot. Opens them in your default browser, if it\'s an user or tag they will be opened in tut  
 **m** = media. Opens the media with xdg-open
 
+## Search
+
+**/** *search-term* = Search for toots, users, or other items in the current pane. Press *Enter* to run the search.  
+**n** = Go to the next match  
+**N** = Go to the previous match
+
 # Commands
 **:quit**
 : Exit tut

--- a/ui/cmdbar.go
+++ b/ui/cmdbar.go
@@ -44,6 +44,11 @@ func (c *CmdBar) ClearInput() {
 	c.View.SetText("")
 }
 
+func (c *CmdBar) SetPaneSearchInput() {
+	c.View.SetFieldTextColor(c.tutView.tut.Config.Style.CommandText)
+	c.View.SetText("/")
+}
+
 func (c *CmdBar) Back() {
 	c.ClearInput()
 	c.View.Autocomplete()
@@ -57,6 +62,16 @@ func (c *CmdBar) DoneFunc(key tcell.Key) {
 	input := c.GetInput()
 	parts := strings.Split(input, " ")
 	if len(parts) == 0 {
+		return
+	}
+	if strings.HasPrefix(input, "/") {
+		term := strings.TrimSpace(input[1:])
+		if term != "" {
+			c.tutView.PaneSearchCommand(term)
+		} else {
+			c.tutView.NextPaneSearch(true)
+		}
+		c.Back()
 		return
 	}
 	switch parts[0] {

--- a/ui/input.go
+++ b/ui/input.go
@@ -22,8 +22,12 @@ func (tv *TutView) Input(event *tcell.EventKey) *tcell.EventKey {
 		case '?':
 			tv.SetPage(HelpFocus)
 		}
+		if event.Rune() == '/' && (tv.PageFocus == MainFocus || tv.PageFocus == ViewFocus) {
+			tv.SetPage(PaneSearchFocus)
+			return nil
+		}
 	}
-	if tv.PageFocus != LoginFocus && tv.PageFocus != CmdFocus {
+	if tv.PageFocus != LoginFocus && tv.PageFocus != CmdFocus && tv.PageFocus != PaneSearchFocus {
 		event = tv.InputLeaderKey(event)
 		if event == nil {
 			return nil
@@ -53,6 +57,8 @@ func (tv *TutView) Input(event *tcell.EventKey) *tcell.EventKey {
 	case LinkFocus:
 		return tv.InputLinkView(event)
 	case CmdFocus:
+		return tv.InputCmdView(event)
+	case PaneSearchFocus:
 		return tv.InputCmdView(event)
 	case MediaFocus:
 		return tv.InputMedia(event)
@@ -221,6 +227,14 @@ func (tv *TutView) InputLeaderKey(event *tcell.EventKey) *tcell.EventKey {
 }
 
 func (tv *TutView) InputMainView(event *tcell.EventKey) *tcell.EventKey {
+	if event.Rune() == 'n' && tv.paneSearchTerm != "" {
+		tv.NextPaneSearch(true)
+		return nil
+	}
+	if event.Rune() == 'N' && tv.paneSearchTerm != "" {
+		tv.NextPaneSearch(false)
+		return nil
+	}
 	switch tv.SubFocus {
 	case ListFocus:
 		return tv.InputMainViewFeed(event)
@@ -352,6 +366,14 @@ func (tv *TutView) InputHelp(event *tcell.EventKey) *tcell.EventKey {
 }
 
 func (tv *TutView) InputViewItem(event *tcell.EventKey) *tcell.EventKey {
+	if event.Rune() == 'n' && tv.paneSearchTerm != "" {
+		tv.NextPaneSearch(true)
+		return nil
+	}
+	if event.Rune() == 'N' && tv.paneSearchTerm != "" {
+		tv.NextPaneSearch(false)
+		return nil
+	}
 	if tv.tut.Config.Input.GlobalBack.Match(event.Key(), event.Rune()) ||
 		tv.tut.Config.Input.GlobalExit.Match(event.Key(), event.Rune()) {
 		tv.FocusMainNoHistory()

--- a/ui/pane_search.go
+++ b/ui/pane_search.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/RasmusLindroth/tut/api"
+	"github.com/RasmusLindroth/tut/util"
+)
+
+func itemSearchText(item api.Item) string {
+	switch item.Type() {
+	case api.StatusType:
+		return statusSearchText(item.Raw().(*mastodon.Status))
+	case api.StatusHistoryType:
+		s := item.Raw().(*mastodon.StatusHistory)
+		status := mastodon.Status{
+			Content:          s.Content,
+			SpoilerText:      s.SpoilerText,
+			Account:          s.Account,
+			MediaAttachments: s.MediaAttachments,
+		}
+		return statusSearchText(&status)
+	case api.UserType, api.ProfileType:
+		return userSearchText(item.Raw().(*api.User))
+	case api.NotificationType:
+		return notificationSearchText(item.Raw().(*api.NotificationData))
+	case api.ListsType:
+		return item.Raw().(*mastodon.List).Title
+	case api.TagType:
+		return item.Raw().(*mastodon.Tag).Name
+	}
+	return ""
+}
+
+func statusSearchText(status *mastodon.Status) string {
+	var b strings.Builder
+	s := util.StatusOrReblog(status)
+	if status.Reblog != nil {
+		b.WriteString(util.FormatUsername(status.Account))
+		b.WriteString(" ")
+	}
+	b.WriteString(util.FormatUsername(s.Account))
+	b.WriteString(" ")
+	b.WriteString(s.SpoilerText)
+	b.WriteString(" ")
+	content, _ := util.CleanHTML(s.Content)
+	b.WriteString(content)
+	for _, a := range s.MediaAttachments {
+		b.WriteString(" ")
+		b.WriteString(a.Description)
+	}
+	if s.Poll != nil {
+		for _, o := range s.Poll.Options {
+			b.WriteString(" ")
+			b.WriteString(o.Title)
+		}
+	}
+	return b.String()
+}
+
+func userSearchText(user *api.User) string {
+	var b strings.Builder
+	b.WriteString(util.FormatUsername(*user.Data))
+	b.WriteString(" ")
+	note, _ := util.CleanHTML(user.Data.Note)
+	b.WriteString(note)
+	for _, f := range user.Data.Fields {
+		b.WriteString(" ")
+		val, _ := util.CleanHTML(f.Value)
+		b.WriteString(val)
+	}
+	return b.String()
+}
+
+func notificationSearchText(nd *api.NotificationData) string {
+	var b strings.Builder
+	b.WriteString(util.FormatUsername(nd.Item.Account))
+	switch nd.Item.Type {
+	case "follow", "follow_request":
+		b.WriteString(" ")
+		b.WriteString(userSearchText(nd.User.Raw().(*api.User)))
+	case "favourite", "reblog", "mention", "update", "status", "poll":
+		b.WriteString(" ")
+		b.WriteString(statusSearchText(nd.Item.Status))
+	}
+	return b.String()
+}
+
+func (tv *TutView) PaneSearchCommand(term string) {
+	tv.paneSearchTerm = strings.ToLower(term)
+	tv.paneSearchIndex = -1
+	tv.NextPaneSearch(true)
+}
+
+func (tv *TutView) NextPaneSearch(forward bool) {
+	if tv.paneSearchTerm == "" {
+		return
+	}
+	f := tv.GetCurrentFeed()
+	items := f.Data.List()
+	count := len(items)
+	if count == 0 {
+		return
+	}
+	start := f.List.Text.GetCurrentItem()
+	if tv.paneSearchIndex >= 0 && tv.paneSearchIndex < count {
+		start = tv.paneSearchIndex
+	}
+	var indices []int
+	if forward {
+		for i := 1; i <= count; i++ {
+			indices = append(indices, (start+i)%count)
+		}
+	} else {
+		for i := 1; i <= count; i++ {
+			indices = append(indices, (start-i+count)%count)
+		}
+	}
+	for _, i := range indices {
+		text := strings.ToLower(itemSearchText(items[i]))
+		if strings.Contains(text, tv.paneSearchTerm) {
+			tv.paneSearchIndex = i
+			f.List.SetCurrentItem(i)
+			f.DrawContent()
+			tv.Shared.Bottom.Cmd.ClearInput()
+			return
+		}
+	}
+	tv.ShowError("No matches found")
+}

--- a/ui/statusbar.go
+++ b/ui/statusbar.go
@@ -33,6 +33,7 @@ const (
 	VoteMode
 	PollMode
 	PreferenceMode
+	PaneSearchMode
 )
 
 func (sb *StatusBar) SetMode(m ViewMode) {
@@ -67,5 +68,7 @@ func (sb *StatusBar) SetMode(m ViewMode) {
 		sb.View.SetText("-- CREATE POLL --")
 	case PreferenceMode:
 		sb.View.SetText("-- PREFERENCES --")
+	case PaneSearchMode:
+		sb.View.SetText("-- SEARCH --")
 	}
 }

--- a/ui/tutview.go
+++ b/ui/tutview.go
@@ -72,6 +72,9 @@ type TutView struct {
 	EditorView     *EditorView
 	ModalView      *ModalView
 
+	paneSearchTerm  string
+	paneSearchIndex int
+
 	FileList []string
 }
 

--- a/ui/view.go
+++ b/ui/view.go
@@ -24,6 +24,7 @@ const (
 	EditorFocus
 	PollFocus
 	PreferenceFocus
+	PaneSearchFocus
 )
 
 func (tv *TutView) GetCurrentFeed() *Feed {
@@ -160,6 +161,11 @@ func (tv *TutView) SetPage(f PageFocusAt) {
 		tv.tut.App.SetFocus(tv.View)
 		tv.Shared.Bottom.StatusBar.SetMode(PreferenceMode)
 		tv.Shared.Top.SetText("preferences")
+	case PaneSearchFocus:
+		tv.PageFocus = PaneSearchFocus
+		tv.tut.App.SetFocus(tv.Shared.Bottom.Cmd.View)
+		tv.Shared.Bottom.StatusBar.SetMode(PaneSearchMode)
+		tv.Shared.Bottom.Cmd.SetPaneSearchInput()
 	}
 	tv.ShouldSync()
 }


### PR DESCRIPTION
Add a pane-local search command triggered by `/<term>` (similar to vi) that searches through all text strings in the currently active feed. Results are navigated with `n` (next match) and `N` (previous match).