### PR TITLE
feat(ui): Add native Mastodon quote post support

### DIFF
--- a/api/feed.go
+++ b/api/feed.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/config"
 )
 

--- a/api/item.go
+++ b/api/item.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/util"
 	"golang.org/x/exp/slices"

--- a/api/poll.go
+++ b/api/poll.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 )
 
 func (ac *AccountClient) Vote(poll *mastodon.Poll, choices ...int) (*mastodon.Poll, error) {

--- a/api/status.go
+++ b/api/status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/util"
 )
 

--- a/api/stream.go
+++ b/api/stream.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 )
 
 type MastodonType uint

--- a/api/tags.go
+++ b/api/tags.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 )
 
 func (ac *AccountClient) FollowTag(tag string) error {

--- a/api/types.go
+++ b/api/types.go
@@ -1,6 +1,6 @@
 package api
 
-import "github.com/RasmusLindroth/go-mastodon"
+import "github.com/blacklight/go-mastodon"
 
 type RequestData struct {
 	MinID mastodon.ID

--- a/api/user.go
+++ b/api/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 )
 
 func (ac *AccountClient) GetUserByID(id mastodon.ID) (Item, error) {

--- a/auth/add.go
+++ b/auth/add.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/util"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -465,6 +465,7 @@ type Input struct {
 	StatusReply        Key
 	StatusBookmark     Key
 	StatusThread       Key
+	StatusQuote        Key
 	StatusUser         Key
 	StatusViewFocus    Key
 	StatusYank         Key
@@ -1311,6 +1312,7 @@ func parseInput(cfg InputTOML) Input {
 	ic.StatusReply = inputOrDef("status-reply", cfg.StatusReply, def.StatusReply, false)
 	ic.StatusBookmark = inputOrDef("status-bookmark", cfg.StatusBookmark, def.StatusBookmark, true)
 	ic.StatusThread = inputOrDef("status-thread", cfg.StatusThread, def.StatusThread, false)
+	ic.StatusQuote = inputOrDef("status-quote", cfg.StatusQuote, def.StatusQuote, false)
 	ic.StatusUser = inputOrDef("status-user", cfg.StatusUser, def.StatusUser, false)
 	ic.StatusViewFocus = inputOrDef("status-view-focus", cfg.StatusViewFocus, def.StatusViewFocus, false)
 	ic.StatusYank = inputOrDef("status-yank", cfg.StatusYank, def.StatusYank, false)

--- a/config/toml.go
+++ b/config/toml.go
@@ -195,6 +195,7 @@ type InputTOML struct {
 	StatusReply        *KeyHintTOML `toml:"status-reply"`
 	StatusBookmark     *KeyHintTOML `toml:"status-bookmark"`
 	StatusThread       *KeyHintTOML `toml:"status-thread"`
+	StatusQuote        *KeyHintTOML `toml:"status-quote"`
 	StatusUser         *KeyHintTOML `toml:"status-user"`
 	StatusViewFocus    *KeyHintTOML `toml:"status-view-focus"`
 	StatusYank         *KeyHintTOML `toml:"status-yank"`

--- a/config/toml_default.go
+++ b/config/toml_default.go
@@ -236,6 +236,10 @@ var ConfigDefault = ConfigTOML{
 			Hint: sp("[T]hread"),
 			Keys: &[]string{"t", "T"},
 		},
+		StatusQuote: &KeyHintTOML{
+			Hint: sp("[X] Quote"),
+			Keys: &[]string{"x", "X"},
+		},
 		StatusUser: &KeyHintTOML{
 			Hint: sp("[U]ser"),
 			Keys: &[]string{"u", "U"},

--- a/config/toot.tmpl
+++ b/config/toot.tmpl
@@ -65,10 +65,20 @@
 {{ Color .Style.Text }}{{ Flags "i" }}{{ .Toot.Card.URL }}{{ Flags "-" }}
 {{ end }}
 {{ end }}
+{{- if .Toot.HasQuote }}
+{{ Color .Style.Subtle }}{{ Flags "b" }}Quote{{ if ne .Toot.QuoteState "" }} ({{ .Toot.QuoteState }}){{ end }}{{ Flags "-" }}
+{{ if ne .Toot.QuoteAccount "" }}{{ if ne .Toot.QuoteDisplayName "" }}{{ Color .Style.TextSpecial2 }}{{ .Toot.QuoteDisplayName }}{{ Color .Style.TextSpecial1 }} ({{ .Toot.QuoteAccount }})
+{{ else }}{{ Color .Style.TextSpecial2 }}{{ .Toot.QuoteAccount }}
+{{ end }}{{ end }}
+{{ if .Toot.QuoteSpoiler }}{{ Color .Style.Text }}{{ .Toot.QuoteCWText }}
+{{ end }}{{ Color .Style.Text }}{{ .Toot.QuoteText }}
+{{ end }}
 {{ Color .Style.Subtle }}Replies
 {{- Color .Style.TextSpecial1 }} {{ .Toot.Replies }}
 {{- Color .Style.Subtle }} Boosts
 {{- Color .Style.TextSpecial1 }} {{ .Toot.Boosts }}
 {{- Color .Style.Subtle }} Favorites
 {{- Color .Style.TextSpecial1 }} {{ .Toot.Favorites }}
+{{- Color .Style.Subtle }} Quotes
+{{- Color .Style.TextSpecial1 }} {{ .Toot.Quotes }}
 {{- Color .Style.TextSpecial2 }} {{ .Toot.Lang }}

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"golang.org/x/exp/slices"

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/RasmusLindroth/tut
 go 1.18
 
 require (
-	github.com/RasmusLindroth/go-mastodon v0.0.21
 	github.com/adrg/xdg v0.4.0
 	github.com/atotto/clipboard v0.1.4
+	github.com/blacklight/go-mastodon v0.0.29
 	github.com/gdamore/tcell/v2 v2.5.4
 	github.com/gen2brain/beeep v0.0.0-20220909211152-5a9ec94374f6
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/RasmusLindroth/go-mastodon v0.0.21 h1:ETr7xxrjQKbGvPlcI9hW7Or/pH2gLTZ6R/IBkQ1vwws=
-github.com/RasmusLindroth/go-mastodon v0.0.21/go.mod h1:Lr6n8V1U2b+9P89YZKsICkNc+oNeJXkygY7raei9SXE=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/blacklight/go-mastodon v0.0.29 h1:WHITlleq9K+fnAUbuZZP1i0XxBQW8iXlm/8OEXzqPbM=
+github.com/blacklight/go-mastodon v0.0.29/go.mod h1:XbpBOtPLP6H1PtLdUHq2cBLzekcJiD/TvxyeiVqpwDE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/util"

--- a/ui/composeview.go
+++ b/ui/composeview.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/util"
@@ -23,6 +23,7 @@ type msgToot struct {
 	Text          string
 	Reply         *mastodon.Status
 	Edit          *mastodon.Status
+	Quote         *mastodon.Status
 	MediaIDs      []mastodon.ID
 	Sensitive     bool
 	CWText        string
@@ -172,7 +173,7 @@ func (cv *ComposeView) SetControls(ctrl ComposeControls) {
 		items = append(items, NewControl(cv.tutView.tut.Config, cv.tutView.tut.Config.Input.ComposeMediaFocus, true))
 		items = append(items, NewControl(cv.tutView.tut.Config, cv.tutView.tut.Config.Input.ComposePoll, true))
 		items = append(items, NewControl(cv.tutView.tut.Config, cv.tutView.tut.Config.Input.ComposeLanguage, true))
-		if cv.msg.Reply != nil {
+		if cv.msg.Reply != nil || cv.msg.Quote != nil {
 			items = append(items, NewControl(cv.tutView.tut.Config, cv.tutView.tut.Config.Input.ComposeIncludeQuote, true))
 		}
 	case ComposeMedia:
@@ -256,6 +257,10 @@ func (cv *ComposeView) SetStatus(reply *mastodon.Status, edit *mastodon.Status) 
 	if cv.tutView.tut.Config.General.QuoteReply && edit == nil {
 		cv.IncludeQuote()
 	}
+	return cv.initComposeUI()
+}
+
+func (cv *ComposeView) initComposeUI() error {
 	cv.visibility.SetLabel("Visibility: ")
 	index := 0
 	for i, v := range visibilitiesStr {
@@ -286,6 +291,44 @@ func (cv *ComposeView) SetStatus(reply *mastodon.Status, edit *mastodon.Status) 
 	cv.UpdateContent()
 	cv.SetControls(ComposeNormal)
 	return nil
+}
+
+func (cv *ComposeView) SetQuote(quote *mastodon.Status) error {
+	if quote != nil && quote.Visibility == mastodon.VisibilityDirectMessage {
+		return fmt.Errorf("cannot quote a direct message")
+	}
+	cv.tutView.PollView.Reset()
+	cv.media.Reset()
+	cv.textAreaMain.SetText("", false)
+	cv.textAreaCW.SetText("", false)
+	msg := &msgToot{}
+	me := cv.tutView.tut.Client.Me
+	visibility := mastodon.VisibilityPublic
+	lang := ""
+	if me.Source != nil && me.Source.Privacy != nil {
+		visibility = *me.Source.Privacy
+	}
+	if me.Source != nil && me.Source.Language != nil {
+		lang = *me.Source.Language
+	}
+	if quote != nil {
+		if quote.Reblog != nil {
+			quote = quote.Reblog
+		}
+		msg.Quote = quote
+		if quote.Sensitive {
+			msg.Sensitive = true
+			msg.CWText = quote.SpoilerText
+		}
+		if visibilities[quote.Visibility] > visibilities[visibility] {
+			visibility = quote.Visibility
+		}
+	}
+	msg.Visibility = visibility
+	msg.Language = lang
+	msg.Text = ""
+	cv.msg = msg
+	return cv.initComposeUI()
 }
 
 func (cv *ComposeView) getAccs() string {
@@ -361,6 +404,14 @@ func (cv *ComposeView) UpdateContent() {
 			acct = cv.msg.Reply.Account.Acct
 		}
 		outputHead += subtleColor + "Replying to " + tview.Escape(acct) + "\n" + normal
+	} else if cv.msg.Quote != nil {
+		var acct string
+		if cv.msg.Quote.Account.DisplayName != "" {
+			acct = fmt.Sprintf("%s (%s)", cv.msg.Quote.Account.DisplayName, cv.msg.Quote.Account.Acct)
+		} else {
+			acct = cv.msg.Quote.Account.Acct
+		}
+		outputHead += subtleColor + "Quoting " + tview.Escape(acct) + "\n" + normal
 	}
 	if cv.msg.CWText != "" && !cv.msg.Sensitive {
 		outputHead += warningColor + "You have entered content warning text, but haven't set an content warning. Do it by pressing " + tview.Escape("[T]") + "\n\n" + normal
@@ -389,6 +440,9 @@ func (cv *ComposeView) IncludeQuote() {
 	}
 	t := cv.msg.Text
 	s := cv.msg.Reply
+	if s == nil {
+		s = cv.msg.Quote
+	}
 	if s == nil {
 		return
 	}
@@ -524,6 +578,10 @@ func (cv *ComposeView) Post() {
 	}
 	if toot.Edit != nil && toot.Edit.InReplyToID != nil {
 		send.InReplyToID = mastodon.ID(toot.Edit.InReplyToID.(string))
+	}
+	if toot.Quote != nil {
+		qid := toot.Quote.ID
+		send.QuotedStatusID = &qid
 	}
 	if toot.Sensitive {
 		send.Sensitive = true

--- a/ui/feed.go
+++ b/ui/feed.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/feed"

--- a/ui/input.go
+++ b/ui/input.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/util"
@@ -552,6 +552,10 @@ func (tv *TutView) InputStatus(event *tcell.EventKey, item api.Item, status *mas
 		tv.Timeline.AddFeed(NewThreadFeed(tv, item, config.NewTimeline(config.Timeline{
 			FeedType: config.Thread,
 		})), false)
+		return nil
+	}
+	if tv.tut.Config.Input.StatusQuote.Match(event.Key(), event.Rune()) {
+		tv.InitQuote(status)
 		return nil
 	}
 	if tv.tut.Config.Input.StatusUser.Match(event.Key(), event.Rune()) {

--- a/ui/item.go
+++ b/ui/item.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/icza/gox/timex"

--- a/ui/item_list.go
+++ b/ui/item_list.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"fmt"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/rivo/tview"
 )
 

--- a/ui/item_status.go
+++ b/ui/item_status.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/config"
 	"github.com/RasmusLindroth/tut/util"
@@ -35,9 +35,20 @@ type Toot struct {
 	Replies            int
 	Boosts             int
 	Favorites          int
+	Quotes             int
 	Edited             bool
 	Lang               string
 	Controls           string
+	HasQuote           bool
+	QuoteState         string
+	QuoteID            string
+	QuoteDisplayName   string
+	QuoteAccount       string
+	QuoteText          string
+	QuoteSpoiler       bool
+	QuoteCWText        string
+	QuoteShowSpoiler   bool
+	QuoteCWlabel       string
 }
 
 type Poll struct {
@@ -200,6 +211,28 @@ func drawStatus(tv *TutView, item api.Item, status *mastodon.Status, main *tview
 	toot.Replies = int(status.RepliesCount)
 	toot.Boosts = int(status.ReblogsCount)
 	toot.Favorites = int(status.FavouritesCount)
+	toot.Quotes = int(status.QuotesCount)
+
+	if status.Quote != nil {
+		toot.HasQuote = true
+		toot.QuoteState = status.Quote.State
+		toot.QuoteID = string(status.Quote.QuotedStatusID)
+		if status.Quote.QuotedStatus != nil {
+			qs := status.Quote.QuotedStatus
+			toot.QuoteDisplayName = tview.Escape(qs.Account.DisplayName)
+			toot.QuoteAccount = tview.Escape(qs.Account.Acct)
+			if qs.Sensitive {
+				toot.QuoteSpoiler = true
+				strippedSpoiler, _ := util.CleanHTMLStyled(qs.SpoilerText)
+				toot.QuoteCWText = strippedSpoiler
+				toot.QuoteShowSpoiler = true
+			}
+			strippedContent, _ := util.CleanHTMLStyled(qs.Content)
+			toot.QuoteText = strippedContent
+		} else {
+			toot.QuoteText = fmt.Sprintf("Quote state: %s", status.Quote.State)
+		}
+	}
 
 	if main != nil {
 		main.ScrollToBeginning()
@@ -229,6 +262,7 @@ func drawStatus(tv *TutView, item api.Item, status *mastodon.Status, main *tview
 	}
 	if !isHistory {
 		info = append(info, NewControl(tv.tut.Config, tv.tut.Config.Input.StatusThread, true))
+		info = append(info, NewControl(tv.tut.Config, tv.tut.Config.Input.StatusQuote, true))
 		info = append(info, NewControl(tv.tut.Config, tv.tut.Config.Input.StatusReply, true))
 		info = append(info, NewControl(tv.tut.Config, tv.tut.Config.Input.StatusViewFocus, true))
 		info = append(info, NewControl(tv.tut.Config, tv.tut.Config.Input.StatusUser, true))

--- a/ui/item_tag.go
+++ b/ui/item_tag.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/rivo/tview"
 )
 

--- a/ui/media.go
+++ b/ui/media.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/atotto/clipboard"
 )
 

--- a/ui/pollview.go
+++ b/ui/pollview.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/ui/preferenceview.go
+++ b/ui/preferenceview.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"fmt"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )

--- a/ui/tutview.go
+++ b/ui/tutview.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
 	"github.com/RasmusLindroth/tut/auth"
 	"github.com/RasmusLindroth/tut/config"

--- a/ui/view.go
+++ b/ui/view.go
@@ -1,10 +1,12 @@
 package ui
 
 import (
+	"fmt"
 	"log"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/RasmusLindroth/tut/api"
+	"github.com/RasmusLindroth/tut/util"
 )
 
 type PageFocusAt uint
@@ -178,6 +180,15 @@ func (tv *TutView) InitPost(status *mastodon.Status, original *mastodon.Status) 
 	err := tv.ComposeView.SetStatus(status, original)
 	if err == nil {
 		tv.SetPage(ComposeFocus)
+	}
+}
+
+func (tv *TutView) InitQuote(status *mastodon.Status) {
+	err := tv.ComposeView.SetQuote(util.StatusOrReblog(status))
+	if err == nil {
+		tv.SetPage(ComposeFocus)
+	} else {
+		tv.ShowError(fmt.Sprintf("Couldn't quote toot. Error: %v\n", err))
 	}
 }
 

--- a/ui/voteview.go
+++ b/ui/voteview.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"fmt"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/rivo/tview"
 )
 

--- a/util/util.go
+++ b/util/util.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/RasmusLindroth/go-mastodon"
+	"github.com/blacklight/go-mastodon"
 	"github.com/adrg/xdg"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/rivo/tview"


### PR DESCRIPTION
This adds support for:

- Quoting posts
- Rendering quotes

It is compatible with the [FEP-044f](https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md) Mastodon specification for quotes.

**NOTE**: It requires my fork of the `go-mastodon` library at the current stage, since the support for the quotes API fields is currently only present there.

If you only want to add that feature, you can cherry-pick commit https://github.com/blacklight/go-mastodon/commit/2f951459578ae396eb43b30ec754e3a8a978a038 and https://github.com/blacklight/go-mastodon/commit/46b79900b2be62b05d5a026649ead652ba5e908a.